### PR TITLE
Add dockerized skeleton for virtual classroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # AulaVirtual
-aula virtual
+
+Este proyecto es un esqueleto de un aula virtual compuesto por:
+
+- **Backend:** API REST en Flask con acceso a PostgreSQL y MongoDB.
+- **Frontend:** Aplicación Angular CLI.
+- **Bases de datos:** PostgreSQL y MongoDB.
+- **Docker:** Todo el stack se ejecuta con Docker mediante `docker-compose`.
+
+## Uso rápido
+
+1. Construir y levantar los contenedores:
+   ```bash
+   docker-compose up --build
+   ```
+
+2. Acceder al frontend en [http://localhost:4200](http://localhost:4200) y al backend en [http://localhost:5000](http://localhost:5000).
+
+Este es solo un punto de partida mínimo. Se deben implementar la lógica de autenticación, las operaciones sobre la base de datos y las vistas de la aplicación.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV FLASK_APP=app.py
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,50 @@
+from flask import Flask, request, jsonify
+from pymongo import MongoClient
+import psycopg2
+import os
+
+app = Flask(__name__)
+
+POSTGRES_URL = os.environ.get('POSTGRES_URL', 'postgresql://postgres:postgres@postgres:5432/postgres')
+MONGO_URL = os.environ.get('MONGO_URL', 'mongodb://mongo:27017/')
+
+# Initialize PostgreSQL connection (placeholder)
+try:
+    pg_conn = psycopg2.connect(POSTGRES_URL)
+    pg_conn.autocommit = True
+except Exception:
+    pg_conn = None
+
+# Initialize MongoDB connection (placeholder)
+try:
+    mongo_client = MongoClient(MONGO_URL)
+    mongo_db = mongo_client.get_database('aula')
+except Exception:
+    mongo_client = None
+    mongo_db = None
+
+@app.route('/api/login', methods=['POST'])
+def login():
+    data = request.json
+    username = data.get('username')
+    password = data.get('password')
+    # TODO: validate user against database
+    return jsonify({'token': 'fake-token', 'user': username})
+
+@app.route('/api/courses')
+def courses():
+    # TODO: fetch courses from database
+    return jsonify({'courses': []})
+
+@app.route('/api/library')
+def library():
+    # TODO: fetch library items from MongoDB
+    return jsonify({'items': []})
+
+@app.route('/api/videos')
+def videos():
+    # TODO: fetch videos from MongoDB
+    return jsonify({'videos': []})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pymongo
+psycopg2-binary
+Flask-Cors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.9'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "5000:5000"
+    environment:
+      POSTGRES_URL: "postgresql://postgres:postgres@postgres:5432/postgres"
+      MONGO_URL: "mongodb://mongo:27017/"
+    depends_on:
+      - postgres
+      - mongo
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  mongo:
+    image: mongo:5
+    volumes:
+      - mongo_data:/data/db
+  frontend:
+    build: ./frontend
+    ports:
+      - "4200:4200"
+    depends_on:
+      - backend
+volumes:
+  postgres_data:
+  mongo_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install -g @angular/cli && npm install
+COPY . .
+EXPOSE 4200
+CMD ["npm", "start"]

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "projects": {
+    "app": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.json"
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "app:build"
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "app"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "aula-virtual",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/animations": "^15.0.0",
+    "@angular/common": "^15.0.0",
+    "@angular/compiler": "^15.0.0",
+    "@angular/core": "^15.0.0",
+    "@angular/forms": "^15.0.0",
+    "@angular/platform-browser": "^15.0.0",
+    "@angular/platform-browser-dynamic": "^15.0.0",
+    "@angular/router": "^15.0.0",
+    "rxjs": "^7.5.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.11.4"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "~15.0.0",
+    "@angular/cli": "~15.0.0",
+    "@angular/compiler-cli": "~15.0.0",
+    "typescript": "~4.8.2"
+  }
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `<h1>Aula Virtual</h1>`
+})
+export class AppComponent {}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule, Routes } from '@angular/router';
+import { AppComponent } from './app.component';
+
+const routes: Routes = [
+  { path: '', component: AppComponent }
+];
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, RouterModule.forRoot(routes)],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AulaVirtual</title>
+  <base href="/">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2015",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2018", "dom"]
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Flask backend with MongoDB and PostgreSQL placeholders
- dockerize backend and frontend
- provide Angular CLI skeleton for frontend
- add docker-compose stack and basic README

## Testing
- `python -m py_compile backend/app.py`
- `docker-compose config` *(fails: command not found)*
- `npm install` in `frontend` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_b_685ca5048a0c8320b32ce66188dcb1e4